### PR TITLE
ES-842 Added idrepo GET get-identity endpoint support 

### DIFF
--- a/mock-plugin/src/main/resources/application.properties
+++ b/mock-plugin/src/main/resources/application.properties
@@ -23,10 +23,10 @@ mosip.signup.mock.identity-verification.story-name=mock-idv-user-story.json
 ## File defined in the property `mosip.signup.mock.identity-verification.story-name` is loaded with below defined URL
 mosip.signup.mock.config-server-url=classpath:
 
-mosip.signup.mock.mandatory-attributes.CREATE=fullName,phone,password,preferredLang
+mosip.signup.mock.mandatory-attributes.CREATE=fullName,phone,email,gender,password,preferredLang
 mosip.signup.mock.mandatory-attributes.UPDATE=
 mosip.signup.mock.lang-based-attributes=fullName
-mosip.signup.mock.username.field=phone
+mosip.signup.mock.username.field=individualId
 
 mosip.signup.mock.identity.endpoint=${mosip.esignet.mock.domain.url}/v1/mock-identity-system/identity
 mosip.signup.mock.get-identity.endpoint=${mosip.esignet.mock.domain.url}/v1/mock-identity-system/identity/

--- a/mosip-identity-plugin/src/main/resources/application.properties
+++ b/mosip-identity-plugin/src/main/resources/application.properties
@@ -38,6 +38,10 @@ mosip.signup.idrepo.get-status.endpoint=http://credentialrequest.idrepo/v1/crede
 mosip.signup.idrepo.add-identity.request.id=mosip.id.create
 mosip.signup.idrepo.update-identity.request.id=mosip.id.update
 mosip.signup.idrepo.identity.request.version=v1
-mosip.signup.idrepo.mandatory-language=khm
+mosip.signup.idrepo.mandatory-language=eng
 mosip.signup.idrepo.optional-language=eng
-mosip.signup.idrepo.idvid-postfix=@phone
+mosip.signup.idrepo.idvid-postfix=
+
+## This is required for id-repo backward compatibility
+mosip.signup.idrepo.get-identity-method=GET
+mosip.signup.idrepo.get-identity-fallback-path=%s?type=demo&idType=HANDLE

--- a/mosip-identity-plugin/src/test/java/io/mosip/signup/plugin/mosipid/service/IdrepoProfileRegistryPluginImplTest.java
+++ b/mosip-identity-plugin/src/test/java/io/mosip/signup/plugin/mosipid/service/IdrepoProfileRegistryPluginImplTest.java
@@ -59,6 +59,7 @@ public class IdrepoProfileRegistryPluginImplTest {
         ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "generateHashEndpoint","http://localhost:8080/identity/v1/identity/genereateHash/");
         ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "getIdentityEndpoint","http://localhost:8080/identity/v1/identity/");
         ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "mandatoryLanguages",List.of("eng"));
+        ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "getIdentityEndpointMethod", "POST");
         ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "getStatusEndpoint","http://localhost:8080/identity/v1/identity/");
     }
 
@@ -357,6 +358,19 @@ public class IdrepoProfileRegistryPluginImplTest {
                 Mockito.eq(new ParameterizedTypeReference<ResponseWrapper<IdentityResponse>>() {
                 }))).thenReturn(responseEntity);
         ProfileDto profileDto= idrepoProfileRegistryPlugin.getProfile(individualId);
+        Assert.assertNotNull(profileDto);
+        Assert.assertEquals(profileDto.getIndividualId(),"1234567890");
+
+        ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "getIdentityEndpointMethod", "GET");
+        ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "getIdentityEndpointFallbackPath", "%s?type=demo&idType=HANDLE");
+        ReflectionTestUtils.setField(idrepoProfileRegistryPlugin, "postfix", "@someid");
+
+        Mockito.when(restTemplate.exchange(
+                "http://localhost:8080/identity/v1/identity/1234567890@someid?type=demo&idType=HANDLE",
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<ResponseWrapper<IdentityResponse>>() {})).thenReturn(responseEntity);
+        profileDto= idrepoProfileRegistryPlugin.getProfile(individualId);
         Assert.assertNotNull(profileDto);
         Assert.assertEquals(profileDto.getIndividualId(),"1234567890");
     }


### PR DESCRIPTION
1. Plugin was written to support upcoming version of the get-identity endpoint in id-repo service. Added flag based support to switch to GET versions of the endpoint.

2. Updated the configurations with ideal default values.