### PR TITLE
[ES-1899] converted two-letter language codes to their corresponding …

### DIFF
--- a/mock-plugin/src/test/java/io/mosip/esignet/plugin/mock/service/MockAuthenticationServiceTest.java
+++ b/mock-plugin/src/test/java/io/mosip/esignet/plugin/mock/service/MockAuthenticationServiceTest.java
@@ -259,6 +259,22 @@ public class MockAuthenticationServiceTest {
         );
         Assert.assertEquals("mock-ida-005", exception.getErrorCode());
     }
+
+    @Test
+    public void convertLangCodesToISO3LanguageCodes_withInvalidInput_thenReturnEmpty() {
+        Assert.assertTrue(mockAuthenticationService.convertLangCodesToISO3LanguageCodes(null).isEmpty());
+        Assert.assertTrue(mockAuthenticationService.convertLangCodesToISO3LanguageCodes(new String[]{}).isEmpty());
+        Assert.assertTrue(mockAuthenticationService.convertLangCodesToISO3LanguageCodes(new String[]{"", ""}).isEmpty());
+        Assert.assertTrue(mockAuthenticationService.convertLangCodesToISO3LanguageCodes(new String[]{"e1"}).isEmpty());
+    }
+
+    @Test
+    public void convertLangCodesToISO3LanguageCodes_withValidInput_thenPass() {
+        List<String> langCodes = mockAuthenticationService.convertLangCodesToISO3LanguageCodes(new String[]{"en", "km"});
+        Assert.assertFalse(langCodes.isEmpty());
+        Assert.assertEquals(langCodes.get(0), "eng");
+        Assert.assertEquals(langCodes.get(1), "khm");
+    }
 }
 
 


### PR DESCRIPTION
…ISO 639-2/T language codes