### PR TITLE
ES-KeyManagerVersion Update - key manager version update

### DIFF
--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -85,7 +85,7 @@
 		<spring-cloud.version>Hoxton.SR8</spring-cloud.version>
 		<spring.boot.version>2.3.6.RELEASE</spring.boot.version>
 
-		<kernel-keymanager-service.version>1.2.1.0</kernel-keymanager-service.version>
+		<kernel-keymanager-service.version>1.2.2.0-SNAPSHOT</kernel-keymanager-service.version>
 		<esignet.version>1.6.1-SNAPSHOT</esignet.version>
 		<esignet-signup.version>1.2.1-SNAPSHOT</esignet-signup.version>
 

--- a/mock-plugin/src/test/java/io/mosip/esignet/plugin/mock/service/MockKeyBindingWrapperServiceTest.java
+++ b/mock-plugin/src/test/java/io/mosip/esignet/plugin/mock/service/MockKeyBindingWrapperServiceTest.java
@@ -103,7 +103,7 @@ public class MockKeyBindingWrapperServiceTest {
     public void doKeyBinding_withValidDetails_thenPass() throws Exception {
         ReflectionTestUtils.setField(mockKeyBindingWrapperService, "supportedBindAuthFactorTypes", List.of("WLA")) ;
         ReflectionTestUtils.setField(mockKeyBindingWrapperService, "expireInDays", 10) ;
-        ReflectionTestUtils.setField(mockKeyBindingWrapperService,"getIdentityEndpoint","http://localhost:8080"); ;
+        ReflectionTestUtils.setField(mockKeyBindingWrapperService,"getIdentityEndpoint","http://localhost:8080/"); ;
 
         KycAuthResult kycAuthResult = new KycAuthResult();
         kycAuthResult.setKycToken("testKycToken");
@@ -167,7 +167,7 @@ public class MockKeyBindingWrapperServiceTest {
     public void doKeyBinding_withInValidKycAuthResult_thenFail() throws Exception {
         ReflectionTestUtils.setField(mockKeyBindingWrapperService, "supportedBindAuthFactorTypes", List.of("WLA")) ;
         ReflectionTestUtils.setField(mockKeyBindingWrapperService, "expireInDays", 10) ;
-        ReflectionTestUtils.setField(mockKeyBindingWrapperService,"getIdentityEndpoint","http://localhost:8080"); ;
+        ReflectionTestUtils.setField(mockKeyBindingWrapperService,"getIdentityEndpoint","http://localhost:8080/"); ;
 
         Mockito.when(mockHelperService.doKycAuthMock(Mockito.anyString(),Mockito.anyString(),Mockito.any(),Mockito.anyBoolean()))
                 .thenReturn(null);
@@ -183,7 +183,7 @@ public class MockKeyBindingWrapperServiceTest {
     public void doKeyBinding_withInValidDetails_thenFail() throws Exception {
         ReflectionTestUtils.setField(mockKeyBindingWrapperService, "supportedBindAuthFactorTypes", List.of("WLA")) ;
         ReflectionTestUtils.setField(mockKeyBindingWrapperService, "expireInDays", 10) ;
-        ReflectionTestUtils.setField(mockKeyBindingWrapperService,"getIdentityEndpoint","http://localhost:8080"); ;
+        ReflectionTestUtils.setField(mockKeyBindingWrapperService,"getIdentityEndpoint","http://localhost:8080/"); ;
 
         KycAuthResult kycAuthResult = new KycAuthResult();
         kycAuthResult.setKycToken("testKycToken");

--- a/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockProfileRegistryPluginImplTest.java
+++ b/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockProfileRegistryPluginImplTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -34,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(SpringRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class MockProfileRegistryPluginImplTest {
 
 

--- a/mosip-identity-plugin/pom.xml
+++ b/mosip-identity-plugin/pom.xml
@@ -85,7 +85,7 @@
 		<spring-cloud.version>Hoxton.SR8</spring-cloud.version>
 		<spring.boot.version>2.3.6.RELEASE</spring.boot.version>
 
-		<kernel-keymanager-service.version>1.2.1.0</kernel-keymanager-service.version>
+		<kernel-keymanager-service.version>1.2.2.0-SNAPSHOT</kernel-keymanager-service.version>
 		<esignet.version>1.6.1-SNAPSHOT</esignet.version>
 		<esignet-signup.version>1.2.1-SNAPSHOT</esignet-signup.version>
 


### PR DESCRIPTION
MockProfileRegistryPluginImplTest : changed SpingRunner to MockitoJUnitRunner .

MockKeyBindingWrapperServiceTest: changed path for getIdentityEndPoint, missing / after port number