### PR TITLE
[ES-2393] Mock plugin java11 to java21 migration

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-maven-mock-plugin:
-    uses: mosip/kattu/.github/workflows/maven-build.yml@master
+    uses: mosip/kattu/.github/workflows/maven-build.yml@master-java21
     with:
       SERVICE_LOCATION: ./mock-plugin
       BUILD_ARTIFACT: mock-plugin
@@ -37,7 +37,7 @@ jobs:
   publish-mock-plugin-to-nexus:
     if: "${{ !contains(github.ref, 'master') && github.event_name != 'pull_request' && github.event_name != 'release' && github.event_name != 'prerelease' && github.event_name != 'publish' }}"
     needs: build-maven-mock-plugin
-    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master
+    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master-java21
     with:
       SERVICE_LOCATION: ./mock-plugin
     secrets:
@@ -51,7 +51,7 @@ jobs:
   sonar-analysis-mock-plugin:
     needs: build-maven-mock-plugin
     if: "${{  github.event_name != 'pull_request' }}"
-    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master
+    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master-java21
     with:
       SERVICE_LOCATION: ./mock-plugin
     secrets:
@@ -64,7 +64,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   build-maven-mosip-identity-plugin:
-    uses: mosip/kattu/.github/workflows/maven-build.yml@master
+    uses: mosip/kattu/.github/workflows/maven-build.yml@master-java21
     with:
       SERVICE_LOCATION: ./mosip-identity-plugin
       BUILD_ARTIFACT: mosip-identity-plugin
@@ -78,7 +78,7 @@ jobs:
   publish-mosip-identity-plugin-to-nexus:
     if: "${{ !contains(github.ref, 'master') && github.event_name != 'pull_request' && github.event_name != 'release' && github.event_name != 'prerelease' && github.event_name != 'publish' }}"
     needs: build-maven-mosip-identity-plugin
-    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master
+    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master-java21
     with:
       SERVICE_LOCATION: ./mosip-identity-plugin
     secrets:
@@ -92,7 +92,7 @@ jobs:
   sonar-analysis-mosip-identity-plugin:
     needs: build-maven-mosip-identity-plugin
     if: "${{  github.event_name != 'pull_request' }}"
-    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master
+    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master-java21
     with:
       SERVICE_LOCATION: ./mosip-identity-plugin
     secrets:
@@ -105,7 +105,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   build-maven-sunbird-rc-plugin:
-    uses: mosip/kattu/.github/workflows/maven-build.yml@master
+    uses: mosip/kattu/.github/workflows/maven-build.yml@master-java21
     with:
       SERVICE_LOCATION: ./sunbird-rc-plugin
       BUILD_ARTIFACT: sunbird-rc-plugin
@@ -119,7 +119,7 @@ jobs:
   publish-sunbird-rc-plugin-to-nexus:
     if: "${{ !contains(github.ref, 'master') && github.event_name != 'pull_request' && github.event_name != 'release' && github.event_name != 'prerelease' && github.event_name != 'publish' }}"
     needs: build-maven-sunbird-rc-plugin
-    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master
+    uses: mosip/kattu/.github/workflows/maven-publish-to-nexus.yml@master-java21
     with:
       SERVICE_LOCATION: ./sunbird-rc-plugin
     secrets:
@@ -133,7 +133,7 @@ jobs:
   sonar-analysis-sunbird-rc-plugin:
     needs: build-maven-sunbird-rc-plugin
     if: "${{  github.event_name != 'pull_request' }}"
-    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master
+    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@master-java21
     with:
       SERVICE_LOCATION: ./sunbird-rc-plugin
     secrets:

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -98,7 +98,7 @@
 
 		<kernel-keymanager-service.version>1.3.0-beta.4</kernel-keymanager-service.version>
 		<esignet.version>1.7.1-SNAPSHOT</esignet.version>
-		<esignet-signup.version>1.3.0-SNAPSHOT</esignet-signup.version>
+		<esignet-signup.version>1.3.1-SNAPSHOT</esignet-signup.version>
 
 		<sonar.exclusions>**/dto/**,**/entity/**,**/exception/**,**/spi/**,**/advice/**,**/config/**</sonar.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -53,17 +53,6 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<repository>
-			<id>gcs-maven-central-mirror</id>
-			<name>GCS Maven Central mirror</name>
-			<url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
 	</repositories>
 
 	<distributionManagement>

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -53,6 +53,17 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+		<repository>
+			<id>gcs-maven-central-mirror</id>
+			<name>GCS Maven Central mirror</name>
+			<url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>
@@ -82,7 +93,7 @@
 		<maven.javadoc.version>3.4.0</maven.javadoc.version>
 		<maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
 
-		<spring-cloud.version>2023.0.4</spring-cloud.version>
+		<spring-cloud.version>2023.0.8</spring-cloud.version>
 		<spring.boot.version>3.2.12</spring.boot.version>
 
 		<kernel-keymanager-service.version>1.3.0-beta.4</kernel-keymanager-service.version>
@@ -159,7 +170,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.19.0</version>
+			<version>5.20.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -280,7 +291,6 @@
 					<skip>false</skip>
 					<argLine>
 						${argLine} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
-						--illegal-access=permit
 					</argLine>
 				</configuration>
 			</plugin>

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -53,6 +53,17 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+        <repository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
 	</repositories>
 
 	<distributionManagement>
@@ -92,17 +103,6 @@
 		<sonar.exclusions>**/dto/**,**/entity/**,**/exception/**,**/spi/**,**/advice/**,**/config/**</sonar.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>
 	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-dependencies</artifactId>
-				<version>${spring.boot.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -161,10 +161,6 @@
 			<artifactId>mockito-core</artifactId>
 			<version>5.20.0</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -53,17 +53,6 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-        <repository>
-            <id>gcs-maven-central-mirror</id>
-            <name>GCS Maven Central mirror</name>
-            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
 	</repositories>
 
 	<distributionManagement>

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -53,6 +53,17 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+		<repository>
+			<id>gcs-maven-central-mirror</id>
+			<name>GCS Maven Central mirror</name>
+			<url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>
@@ -67,32 +78,42 @@
 	</distributionManagement>
 
 	<properties>
-		<java.version>11</java.version>
+		<java.version>21</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- maven -->
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
-		<maven.compiler.version>3.8.0</maven.compiler.version>
-		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
-		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
-		<maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
-		<maven.jacoco.version>0.8.5</maven.jacoco.version>
-		<maven.sonar.plugin.version>3.7.0.1746</maven.sonar.plugin.version>
-		<maven.javadoc.version>3.2.0</maven.javadoc.version>
-		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.version>3.14.1</maven.compiler.version>
+		<maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
+		<maven.war.plugin.version>3.5.0</maven.war.plugin.version>
+		<maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
+		<maven.jacoco.version>0.8.14</maven.jacoco.version>
+		<maven.sonar.plugin.version>3.9.1.2184</maven.sonar.plugin.version>
+		<maven.javadoc.version>3.4.0</maven.javadoc.version>
+		<maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
 
-		<spring-cloud.version>Hoxton.SR8</spring-cloud.version>
-		<spring.boot.version>2.3.6.RELEASE</spring.boot.version>
+		<spring-cloud.version>2023.0.4</spring-cloud.version>
+		<spring.boot.version>3.2.12</spring.boot.version>
 
-		<kernel-keymanager-service.version>1.2.2.0-SNAPSHOT</kernel-keymanager-service.version>
-		<esignet.version>1.7.0-SNAPSHOT</esignet.version>
+		<kernel-keymanager-service.version>1.3.0-beta.4</kernel-keymanager-service.version>
+		<esignet.version>1.7.1-SNAPSHOT</esignet.version>
 		<esignet-signup.version>1.3.0-SNAPSHOT</esignet-signup.version>
 
 		<sonar.exclusions>**/dto/**,**/entity/**,**/exception/**,**/spi/**,**/advice/**,**/config/**</sonar.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>
 	</properties>
-
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring.boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -104,7 +125,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.42</version>
 			<scope>compile</scope>
 		</dependency>
 
@@ -145,6 +166,16 @@
 			<artifactId>signup-integration-api</artifactId>
 			<version>${esignet-signup.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.19.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/mock-plugin/src/test/java/io/mosip/esignet/plugin/mock/service/MockHelperServiceTest.java
+++ b/mock-plugin/src/test/java/io/mosip/esignet/plugin/mock/service/MockHelperServiceTest.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.mosip.esignet.api.dto.*;
+import io.mosip.esignet.api.dto.AuthChallenge;
+import io.mosip.esignet.api.dto.KycAuthDto;
+import io.mosip.esignet.api.dto.KycAuthResult;
+import io.mosip.esignet.api.dto.SendOtpResult;
 import io.mosip.esignet.api.exception.KycAuthException;
 import io.mosip.esignet.api.exception.SendOtpException;
 import io.mosip.esignet.api.util.ErrorConstants;
@@ -14,7 +17,6 @@ import io.mosip.kernel.core.http.ResponseWrapper;
 import io.mosip.kernel.signature.dto.JWTSignatureResponseDto;
 import io.mosip.kernel.signature.service.SignatureService;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -28,8 +30,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -51,34 +51,6 @@ public class MockHelperServiceTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-
-    @Before
-    public void setUp() throws Exception {
-        // Create the map you want to set
-        Map<String, List<String>> supportedKycAuthFormats = new HashMap<>();
-        supportedKycAuthFormats.put("OTP", List.of("alpha-numeric"));
-        supportedKycAuthFormats.put("PIN", List.of("number"));
-        supportedKycAuthFormats.put("BIO", List.of("encoded-json"));
-        supportedKycAuthFormats.put("WLA", List.of("jwt"));
-        supportedKycAuthFormats.put("KBI", List.of("base64url-encoded-json"));
-        supportedKycAuthFormats.put("PWD", List.of("alpha-numeric"));
-
-        // Get the field
-        Field field = MockHelperService.class.getDeclaredField("supportedKycAuthFormats");
-
-        // Make the field accessible
-        field.setAccessible(true);
-
-        // Remove the final modifier
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        int modifiers = field.getModifiers();
-        modifiers &= ~Modifier.FINAL; // Clear the FINAL bit
-        modifiersField.setInt(field, modifiers);
-
-        // Now you can set the field value
-        field.set(null, supportedKycAuthFormats); // Setting static field
-    }
 
     @Test
     public void doKycAuthMock_withAuthFactorAsOTP_thenPass() throws KycAuthException {

--- a/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
+++ b/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
@@ -7,8 +7,6 @@ import io.mosip.signup.api.dto.*;
 import io.mosip.signup.api.exception.IdentityVerifierException;
 import io.mosip.signup.api.util.VerificationStatus;
 import io.mosip.signup.plugin.mock.verifier.MockIdentityVerifierPluginImpl;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +19,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.support.SendResult;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
@@ -30,7 +27,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -73,14 +69,6 @@ public class MockIdentityVerifierPluginImplTest {
         ReflectionTestUtils.setField(mockIdentityVerifierPlugin, "kafkaTemplate", kafkaTemplate);
         ReflectionTestUtils.setField(mockIdentityVerifierPlugin, "resultTopic", "ANALYZE_FRAMES_RESULT");
 
-        RecordMetadata metadata = Mockito.mock(RecordMetadata.class);
-        ProducerRecord<String, IdentityVerificationResult> record =
-                new ProducerRecord<>("ANALYZE_FRAMES_RESULT", new IdentityVerificationResult());
-        SendResult<String, IdentityVerificationResult> sendResult = new SendResult<>(record, metadata);
-        CompletableFuture<SendResult<String, IdentityVerificationResult>> mockFuture =
-                CompletableFuture.completedFuture(sendResult);
-        Mockito.when(kafkaTemplate.send(Mockito.anyString(), Mockito.any(IdentityVerificationResult.class)))
-                .thenReturn(mockFuture);
         mockIdentityVerifierPlugin.verify(transactionId, identityVerificationDto);
 
         Mockito.verify(resourceLoader).getResource(Mockito.anyString());
@@ -89,10 +77,8 @@ public class MockIdentityVerifierPluginImplTest {
                 Mockito.eq("ANALYZE_FRAMES_RESULT"),
                 resultCaptor.capture()
         );
-        List<IdentityVerificationResult> capturedResults = resultCaptor.getAllValues();
-        Assert.assertEquals(2, capturedResults.size());
-        Assert.assertEquals("transactionId123", capturedResults.get(0).getId());
     }
+
     @Test
     public void getVerifiedResult_withValidTransactionId_thenPass() throws IdentityVerifierException, IOException {
 

--- a/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
+++ b/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
@@ -3,7 +3,8 @@ package io.mosip.signup.plugin.mock.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mosip.signup.api.dto.*;
+import io.mosip.signup.api.dto.IdentityVerificationInitDto;
+import io.mosip.signup.api.dto.VerificationResult;
 import io.mosip.signup.api.exception.IdentityVerifierException;
 import io.mosip.signup.api.util.VerificationStatus;
 import io.mosip.signup.plugin.mock.verifier.MockIdentityVerifierPluginImpl;
@@ -11,21 +12,17 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -49,7 +46,7 @@ public class MockIdentityVerifierPluginImplTest {
     }
 
 
-    @Test
+   /* @Test
     public void verify_withValidIdentityVerificationDto_thenPass() throws IdentityVerifierException, IOException {
 
         String transactionId = "transactionId123";
@@ -79,7 +76,7 @@ public class MockIdentityVerifierPluginImplTest {
                 Mockito.eq("ANALYZE_FRAMES_RESULT"),
                 resultCaptor.capture()
         );
-    }
+    }*/
 
 
     @Test

--- a/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
+++ b/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
@@ -48,8 +48,10 @@ public class MockIdentityVerifierPluginImplTest {
         ReflectionTestUtils.setField(mockIdentityVerifierPlugin, "resultTopic","ANALYZE_FRAMES_RESULT");
     }
 
+
     @Test
     public void verify_withValidIdentityVerificationDto_thenPass() throws IdentityVerifierException, IOException {
+
         String transactionId = "transactionId123";
         IdentityVerificationDto identityVerificationDto = new IdentityVerificationDto();
         identityVerificationDto.setStepCode("START");
@@ -78,6 +80,7 @@ public class MockIdentityVerifierPluginImplTest {
                 resultCaptor.capture()
         );
     }
+
 
     @Test
     public void getVerifiedResult_withValidTransactionId_thenPass() throws IdentityVerifierException, IOException {

--- a/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
+++ b/mock-plugin/src/test/java/io/mosip/signup/plugin/mock/service/MockIdentityVerifierPluginImplTest.java
@@ -3,27 +3,34 @@ package io.mosip.signup.plugin.mock.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mosip.signup.api.dto.IdentityVerificationInitDto;
-import io.mosip.signup.api.dto.VerificationResult;
+import io.mosip.signup.api.dto.*;
 import io.mosip.signup.api.exception.IdentityVerifierException;
 import io.mosip.signup.api.util.VerificationStatus;
 import io.mosip.signup.plugin.mock.verifier.MockIdentityVerifierPluginImpl;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -45,10 +52,8 @@ public class MockIdentityVerifierPluginImplTest {
         ReflectionTestUtils.setField(mockIdentityVerifierPlugin, "resultTopic","ANALYZE_FRAMES_RESULT");
     }
 
-
-   /* @Test
+    @Test
     public void verify_withValidIdentityVerificationDto_thenPass() throws IdentityVerifierException, IOException {
-
         String transactionId = "transactionId123";
         IdentityVerificationDto identityVerificationDto = new IdentityVerificationDto();
         identityVerificationDto.setStepCode("START");
@@ -68,6 +73,14 @@ public class MockIdentityVerifierPluginImplTest {
         ReflectionTestUtils.setField(mockIdentityVerifierPlugin, "kafkaTemplate", kafkaTemplate);
         ReflectionTestUtils.setField(mockIdentityVerifierPlugin, "resultTopic", "ANALYZE_FRAMES_RESULT");
 
+        RecordMetadata metadata = Mockito.mock(RecordMetadata.class);
+        ProducerRecord<String, IdentityVerificationResult> record =
+                new ProducerRecord<>("ANALYZE_FRAMES_RESULT", new IdentityVerificationResult());
+        SendResult<String, IdentityVerificationResult> sendResult = new SendResult<>(record, metadata);
+        CompletableFuture<SendResult<String, IdentityVerificationResult>> mockFuture =
+                CompletableFuture.completedFuture(sendResult);
+        Mockito.when(kafkaTemplate.send(Mockito.anyString(), Mockito.any(IdentityVerificationResult.class)))
+                .thenReturn(mockFuture);
         mockIdentityVerifierPlugin.verify(transactionId, identityVerificationDto);
 
         Mockito.verify(resourceLoader).getResource(Mockito.anyString());
@@ -76,9 +89,10 @@ public class MockIdentityVerifierPluginImplTest {
                 Mockito.eq("ANALYZE_FRAMES_RESULT"),
                 resultCaptor.capture()
         );
-    }*/
-
-
+        List<IdentityVerificationResult> capturedResults = resultCaptor.getAllValues();
+        Assert.assertEquals(2, capturedResults.size());
+        Assert.assertEquals("transactionId123", capturedResults.get(0).getId());
+    }
     @Test
     public void getVerifiedResult_withValidTransactionId_thenPass() throws IdentityVerifierException, IOException {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Java requirement to 21 and refreshed build toolchain, Spring Boot, Spring Cloud, Lombok, multiple plugins and library versions.
  * Switched CI workflows to the Java 21 variant.
  * Removed legacy JVM test flag from build configuration.

* **Tests**
  * Added Mockito as a test dependency.
  * Simplified tests by removing an outdated global test initializer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->