### PR TITLE
[ES-2764] added -parameters compiler flag

### DIFF
--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -381,6 +381,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<parameters>true</parameters>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
 				</configuration>

--- a/mosip-identity-plugin/pom.xml
+++ b/mosip-identity-plugin/pom.xml
@@ -511,6 +511,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<parameters>true</parameters>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
 				</configuration>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven compiler configurations to enable parameter name metadata generation in compiled bytecode. Parameter names are now preserved during compilation, providing better support for reflection-based frameworks and tools that require runtime parameter information access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->