### PR TITLE
[ES-2315] setting refId in key generate request - java 21 migration

### DIFF
--- a/mock-plugin/src/main/java/io/mosip/esignet/plugin/mock/service/MockKeyBindingWrapperService.java
+++ b/mock-plugin/src/main/java/io/mosip/esignet/plugin/mock/service/MockKeyBindingWrapperService.java
@@ -174,6 +174,7 @@ public class MockKeyBindingWrapperService implements KeyBinder {
 
     private void setupMockBindingKey() {
         KeyPairGenerateRequestDto mockBindingKeyRequest = new KeyPairGenerateRequestDto();
+        mockBindingKeyRequest.setReferenceId("");
         mockBindingKeyRequest.setApplicationId(BINDING_SERVICE_APP_ID);
         keymanagerService.generateMasterKey("CSR", mockBindingKeyRequest);
         log.info("===================== MOCK_BINDING_SERVICE KEY SETUP COMPLETED ========================");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Added an explicit initialization step for mock key-binding requests prior to key generation to improve internal initialization consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->