### PR TITLE
[ES-2944] New map entry for resetPasswordChallengeFileds

### DIFF
--- a/mosip-identity-plugin/src/main/java/io/mosip/signup/plugin/mosipid/service/IdrepoProfileRegistryPluginImpl.java
+++ b/mosip-identity-plugin/src/main/java/io/mosip/signup/plugin/mosipid/service/IdrepoProfileRegistryPluginImpl.java
@@ -566,7 +566,7 @@ public class IdrepoProfileRegistryPluginImpl implements ProfileRegistryPlugin {
                         Map.entry("i18nValues", i18nValues),
                         Map.entry("language", Map.of("mandatory", mandatoryLanguages, "optional", optionalLanguages)),
                         Map.entry("allowedValues", allowedValues),
-                        Map.entry("maxUploadFileSize", maxUploadFileSize)
+                        Map.entry("maxUploadFileSize", maxUploadFileSize),
                         Map.entry("resetPasswordChallengeFields",resetPasswordChallengeFields)
                 )
         );

--- a/mosip-identity-plugin/src/main/java/io/mosip/signup/plugin/mosipid/service/IdrepoProfileRegistryPluginImpl.java
+++ b/mosip-identity-plugin/src/main/java/io/mosip/signup/plugin/mosipid/service/IdrepoProfileRegistryPluginImpl.java
@@ -157,6 +157,9 @@ public class IdrepoProfileRegistryPluginImpl implements ProfileRegistryPlugin {
     @Value("${mosip.signup.mosipid.uispec.maxuploadfilesize-jsonpath:$[0].jsonSpec[0].spec.maxUploadFileSize}")
     private String maxUploadFileSizeJsonpath;
 
+    @Value("${mosip.signup.mosipid.uispec.resetPasswordChallengeFields-jsonpath:$[0].jsonSpec[0].spec.resetPasswordChallengeFields}")
+    private String resetPasswordChallengeFieldsJsonpath;
+
     @Value("${mosip.signup.mosipid.uispec.errors-jsonpath:$[0].jsonSpec[0].spec.errors}")
     private String errorsJsonpath;
 
@@ -242,6 +245,17 @@ public class IdrepoProfileRegistryPluginImpl implements ProfileRegistryPlugin {
             maxUploadFileSize = 5242880;
         }
         return maxUploadFileSize;
+    }
+
+    private Object readResetPasswordChallengeFields(String responseJson) {
+        Object resetPasswordChallengeFields;
+        try {
+            resetPasswordChallengeFields = JsonPath.read(responseJson, resetPasswordChallengeFieldsJsonpath);
+        } catch (PathNotFoundException e) {
+            log.error("resetPasswordChallengeFields not found in schema");
+            return Collections.emptyList();
+        }
+        return resetPasswordChallengeFields;
     }
 
     /**
@@ -543,6 +557,7 @@ public class IdrepoProfileRegistryPluginImpl implements ProfileRegistryPlugin {
         ObjectNode i18nValues = readI18nValues(responseJson);
         JsonNode allowedValues = readAllowedValues(responseJson);
         Object maxUploadFileSize = readMaxUploadFileSize(responseJson);
+        Object resetPasswordChallengeFields = readResetPasswordChallengeFields(responseJson);
 
         return objectMapper.valueToTree(
                 Map.ofEntries(
@@ -552,6 +567,7 @@ public class IdrepoProfileRegistryPluginImpl implements ProfileRegistryPlugin {
                         Map.entry("language", Map.of("mandatory", mandatoryLanguages, "optional", optionalLanguages)),
                         Map.entry("allowedValues", allowedValues),
                         Map.entry("maxUploadFileSize", maxUploadFileSize)
+                        Map.entry("resetPasswordChallengeFields",resetPasswordChallengeFields)
                 )
         );
     }

--- a/mosip-identity-plugin/src/main/resources/application.properties
+++ b/mosip-identity-plugin/src/main/resources/application.properties
@@ -51,7 +51,7 @@ mosip.signup.idrepo.get-status.endpoint=http://credentialrequest.idrepo/v1/crede
 mosip.signup.mosipid.get-ui-spec.endpoint=http://masterdata.kernel/v1/masterdata/uispec/esignet-signup/latest?type=schema
 mosip.signup.mosipid.uispec.errors={required:{en:"This field is required"},passwordMismatch:{en:"Passwords is not matching please check your password"}}
 
-mosip.signup.mosipid.dynamic-fields.endpoint=http://masterdata.kernel/v1/masterdata/dynamicfields?pageNumber=%d&pageSize=%d"
+mosip.signup.mosipid.dynamic-fields.endpoint=http://masterdata.kernel/v1/masterdata/dynamicfields?pageNumber=%d&pageSize=%d
 
 # for multiple languages scenario, the languages should be appended followed by ampersand as ?languages=eng&languages=fra&languages=khm
 mosip.signup.mosipid.doc-types-category.endpoint=http://masterdata.kernel/v1/masterdata/applicanttype/000/languages?languages=eng


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset now supports configurable challenge fields, which are shown dynamically in the UI for customizable verification.
* **Bug Fixes**
  * Password reset handles absence of challenge fields gracefully to avoid errors or broken UI.
  * Fixed a configuration typo in the backend properties to ensure endpoint parsing works correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->