### PR TITLE
Snapshot version update in all 3 plugins 1.4.0 -> 1.4.1

### DIFF
--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.mosip.esignet</groupId>
 	<artifactId>mock-plugin</artifactId>
-	<version>1.4.0-SNAPSHOT</version>
+	<version>1.4.1-SNAPSHOT</version>
 	<name>mock-plugin</name>
 	<packaging>jar</packaging>
 	<description>Mockup of a wrapper implementation that is used to showcase the integration with e-Signet</description>

--- a/mock-plugin/pom.xml
+++ b/mock-plugin/pom.xml
@@ -86,8 +86,8 @@
 		<spring.boot.version>3.2.12</spring.boot.version>
 
 		<kernel-keymanager-service.version>1.3.0-beta.4</kernel-keymanager-service.version>
-		<esignet.version>1.8.0-SNAPSHOT</esignet.version>
-		<esignet-signup.version>1.4.0-SNAPSHOT</esignet-signup.version>
+		<esignet.version>1.8.1-SNAPSHOT</esignet.version>
+		<esignet-signup.version>1.4.1-SNAPSHOT</esignet-signup.version>
 
 		<sonar.exclusions>**/dto/**,**/entity/**,**/exception/**,**/spi/**,**/advice/**,**/config/**</sonar.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>

--- a/mosip-identity-plugin/pom.xml
+++ b/mosip-identity-plugin/pom.xml
@@ -86,8 +86,8 @@
 		<spring.boot.version>3.2.12</spring.boot.version>
 
 		<kernel-keymanager-service.version>1.3.0-beta.4</kernel-keymanager-service.version>
-		<esignet.version>1.8.0-SNAPSHOT</esignet.version>
-		<esignet-signup.version>1.4.0-SNAPSHOT</esignet-signup.version>
+		<esignet.version>1.8.1-SNAPSHOT</esignet.version>
+		<esignet-signup.version>1.4.1-SNAPSHOT</esignet-signup.version>
 
 		<sonar.exclusions>**/dto/**,**/entity/**,**/exception/**,**/spi/**,**/advice/**,**/config/**</sonar.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>

--- a/mosip-identity-plugin/pom.xml
+++ b/mosip-identity-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>io.mosip.esignet</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1-SNAPSHOT</version>
 	<artifactId>mosip-identity-plugin</artifactId>
 	<name>mosip-identity-plugin</name>
     <description>e-Signet Integration Implementation for MOSIP ID system</description>

--- a/sunbird-rc-plugin/pom.xml
+++ b/sunbird-rc-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.esignet.plugin.sunbirdrc</groupId>
 	<artifactId>sunbird-rc-plugin</artifactId>
-	<version>1.4.0-SNAPSHOT</version>
+	<version>1.4.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	
 	<name>sunbird-rc-plugin</name>

--- a/sunbird-rc-plugin/pom.xml
+++ b/sunbird-rc-plugin/pom.xml
@@ -80,7 +80,7 @@
 		<git-commit-id-plugin.version>3.0.1</git-commit-id-plugin.version>
 		<maven.jacoco.version>0.8.14</maven.jacoco.version>
 		<maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
-		<esignet.version>1.8.0-SNAPSHOT</esignet.version>
+		<esignet.version>1.8.1-SNAPSHOT</esignet.version>
         <maven.sonar.plugin.version>3.9.1.2184</maven.sonar.plugin.version>
 		<sonar.exclusions>**/dto/**,**/entity/**,**/exception/**,**/spi/**,**/advice/**,**/config/**</sonar.exclusions>
 		<sonar.cpd.exclusions>**/dto/**,**/entity/**,**/config/**</sonar.cpd.exclusions>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped plugin release versions from 1.4.0-SNAPSHOT to 1.4.1-SNAPSHOT and updated related library/property versions (e.g., core/integration/signup) to align with 1.8.1-SNAPSHOT / 1.4.1-SNAPSHOT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->