### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Run a single test class:
 
 ```shell
 cd mock-plugin
-mvn test -Dtest=MockAuthenticationServiceTest
+mvn -Dtest=MockAuthenticationServiceTest test
 ```
 
 To build against a specific SNAPSHOT version of `esignet-integration-api` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ CI:
 
 | Module | Purpose |
 |---|---|
-| [`mock-plugin`](mock-plugin/README.md) | Implementation for use with the [Mock IDA system](https://github.com/mosip/esignet-mock-services/tree/master/mock-identity-system). Development/demo use only — not for production. |
-| [`mosip-identity-plugin`](mosip-identity-plugin/README.md) | Integrates eSignet with the [MOSIP IDA system](https://github.com/mosip/id-authentication) and esignet-signup with [MOSIP ID Repository](https://github.com/mosip/id-repository). This is the production plugin. |
-| [`sunbird-rc-plugin`](sunbird-rc-plugin/README.md) | Wraps the [Sunbird-RC](https://github.com/Sunbird-RC/sunbird-rc-core) registry system as an eSignet authenticator/VCI plugin (compatible with Sunbird-RC 1.0.0). |
+| [`mock-plugin`](mock-plugin/README.md) ([`AGENTS.md`](mock-plugin/AGENTS.md)) | Implementation for use with the [Mock IDA system](https://github.com/mosip/esignet-mock-services/tree/master/mock-identity-system). Development/demo use only — not for production. |
+| [`mosip-identity-plugin`](mosip-identity-plugin/README.md) ([`AGENTS.md`](mosip-identity-plugin/AGENTS.md)) | Integrates eSignet with the [MOSIP IDA system](https://github.com/mosip/id-authentication) and esignet-signup with [MOSIP ID Repository](https://github.com/mosip/id-repository). This is the production plugin. |
+| [`sunbird-rc-plugin`](sunbird-rc-plugin/README.md) ([`AGENTS.md`](sunbird-rc-plugin/AGENTS.md)) | Wraps the [Sunbird-RC](https://github.com/Sunbird-RC/sunbird-rc-core) registry system as an eSignet authenticator/VCI plugin (compatible with Sunbird-RC 1.0.0). |
 
 Each module's own `README.md` is the authoritative source for that module's
 configuration properties, dependent services, and database entries — this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,18 +70,19 @@ Run a single test class:
 
 ```shell
 cd mock-plugin
-mvn -Dtest=MockAuthenticationServiceTest test
+mvn test -Dtest=MockAuthenticationServiceTest
 ```
 
 To build against a specific SNAPSHOT version of `esignet-integration-api` /
 `signup-integration-api` (both are `provided`-scope dependencies resolved
 from the OSSRH snapshot repository declared in each module's `pom.xml`),
-override the version property before the goal, not after the module path —
-system properties (`-D...`) must precede the goal on the Maven command line:
+override the version property (Maven's CLI parser accepts `-D` in either
+position relative to the goal — position it after the goal, matching the
+style used elsewhere in this file):
 
 ```shell
 cd mosip-identity-plugin
-mvn -Designet.version=1.6.0-SNAPSHOT clean install
+mvn clean install -Designet.version=1.6.0-SNAPSHOT
 ```
 
 ## Configuration
@@ -177,7 +178,7 @@ Actions secrets.
 2. Read the target module's own `README.md` before changing its configuration or documenting new properties — it is the source of truth for that module's setup.
 3. Keep new provider/service implementation classes in the correct existing package (`io.mosip.esignet.plugin.<module>` or `io.mosip.signup.plugin.<module>`) matching the interface being implemented.
 4. Target the `develop` branch for new branches and PRs.
-5. Place any `-D` system property before the Maven goal on the command line (e.g. `mvn -Dproperty=value clean install`), never after.
+5. Write Maven `-D` system properties after the goal on the command line (e.g. `mvn clean install -Dproperty=value`), matching the style used throughout this file — Maven's CLI parser accepts either position, this is just for consistency. (This is unrelated to a plain `java -jar` command, where `-D` flags genuinely must precede `-jar` for the JVM to recognize them.)
 
 ### Do not
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,188 @@
+# AGENTS.md
+
+## Repository Overview
+
+This repository hosts the Java runtime-dependency plugins used by
+[esignet](https://github.com/mosip/esignet) and
+[esignet-signup](https://github.com/mosip/esignet-signup). Each plugin
+implements the interfaces defined in `esignet-integration-api` and/or
+`signup-integration-api` and is bundled as a runtime jar into the eSignet
+service images. MOSIP publishes two image flavors: a base `esignet` image and
+an `esignet-with-plugins` image that bundles the plugins from this repo.
+
+There is no root aggregator `pom.xml` — the repository is a flat collection
+of three independent Maven modules, each built and published on its own by
+CI:
+
+| Module | Purpose |
+|---|---|
+| [`mock-plugin`](mock-plugin/README.md) | Implementation for use with the [Mock IDA system](https://github.com/mosip/esignet-mock-services/tree/master/mock-identity-system). Development/demo use only — not for production. |
+| [`mosip-identity-plugin`](mosip-identity-plugin/README.md) | Integrates eSignet with the [MOSIP IDA system](https://github.com/mosip/id-authentication) and esignet-signup with [MOSIP ID Repository](https://github.com/mosip/id-repository). This is the production plugin. |
+| [`sunbird-rc-plugin`](sunbird-rc-plugin/README.md) | Wraps the [Sunbird-RC](https://github.com/Sunbird-RC/sunbird-rc-core) registry system as an eSignet authenticator/VCI plugin (compatible with Sunbird-RC 1.0.0). |
+
+Each module's own `README.md` is the authoritative source for that module's
+configuration properties, dependent services, and database entries — this
+file does not repeat that detail, only points to it.
+
+## Technology Stack
+
+- Language: Java 21 (`java.version`, `maven.compiler.source/target` are all
+  `21` in every module's `pom.xml`)
+- Build tool: Apache Maven (no Maven Wrapper committed — use a locally
+  installed `mvn`)
+- Test: JUnit via `maven-surefire-plugin` (version `3.1.2`), coverage via
+  `jacoco-maven-plugin` (version `0.8.14`) in each module
+- Packaging: plain `jar` for `mock-plugin` and `sunbird-rc-plugin`;
+  `mosip-identity-plugin` additionally uses `maven-assembly-plugin` with
+  `src/assembly.xml`
+- Artifacts published to Maven Central / Sonatype OSSRH snapshots
+  (`https://central.sonatype.com/repository/maven-snapshots`)
+
+## Build & Test Commands
+
+Each module is built independently — there is no parent `pom.xml` to build
+all three from the repo root. Run Maven from inside the module directory you
+are changing:
+
+```shell
+cd mock-plugin
+mvn clean install
+```
+
+```shell
+cd mosip-identity-plugin
+mvn clean install
+```
+
+```shell
+cd sunbird-rc-plugin
+mvn clean install
+```
+
+Run only the tests for a module:
+
+```shell
+cd mock-plugin
+mvn test
+```
+
+Run a single test class:
+
+```shell
+cd mock-plugin
+mvn test -Dtest=MockAuthenticationServiceTest
+```
+
+To build against a specific SNAPSHOT version of `esignet-integration-api` /
+`signup-integration-api` (both are `provided`-scope dependencies resolved
+from the OSSRH snapshot repository declared in each module's `pom.xml`),
+override the version property before the goal, not after the module path —
+system properties (`-D...`) must precede the goal on the Maven command line:
+
+```shell
+cd mosip-identity-plugin
+mvn -Designet.version=1.6.0-SNAPSHOT clean install
+```
+
+## Configuration
+
+There are no secrets or local-override property files checked into this
+repository. Each module ships one `src/main/resources/application.properties`
+with default values for its own plugin; there is no
+`application-local.properties` or similar override file in any module.
+Configuration works by env-var overrides at the host application
+(esignet-service / signup-service) level, as described in each module's
+README:
+
+- `mock-plugin/src/main/resources/application.properties`
+- `mosip-identity-plugin/src/main/resources/application.properties`
+- `sunbird-rc-plugin/src/main/resources/application.properties`
+
+`mosip-identity-plugin` additionally requires values that have no default and
+must be supplied by the deployer: `mosip.ida.client.secret` and
+`mosip.esignet.misp.key` (see
+[mosip-identity-plugin/README.md](mosip-identity-plugin/README.md)).
+
+Never commit real values for these, or for any Nexus/OSSRH/GPG credentials
+used by the release workflow (see below) — they are supplied only as GitHub
+Actions secrets.
+
+## Project Structure Notes
+
+- `mock-plugin/`, `mosip-identity-plugin/`, `sunbird-rc-plugin/` — the three
+  independent plugin modules described above. Each has its own `pom.xml`,
+  `README.md`, `src/main/java`, `src/main/resources`, and `src/test/java`.
+- `.github/workflows/push-trigger.yml` — on every push to `master`, `develop`,
+  `1.*`, `MOSIP*`, or `release*`, and on PR open/reopen/sync, builds all three
+  modules independently (one `build-maven-<module>` job per module) using the
+  shared `mosip/kattu` reusable workflows. On non-PR, non-release pushes off
+  `master`, each module is also published to Nexus and Sonar-analyzed.
+- `.github/workflows/codeql.yml` — runs CodeQL static analysis (Java/Kotlin)
+  on pushes and PRs targeting `develop`, plus a weekly schedule.
+- No root `pom.xml`: do not try to build "the whole repo" with one Maven
+  invocation from the repo root — it will not find a project there.
+
+## Development Workflow
+
+1. Fork the repository and clone your fork.
+2. Branch from `develop` (the active integration branch; CI, including
+   CodeQL, targets `develop`).
+3. Make changes inside the one module your change concerns. Cross-module
+   changes are rare because the modules do not depend on each other.
+4. Run `mvn clean install` (or at least `mvn test`) inside that module
+   before opening a PR.
+5. Keep new/changed classes under the module's existing package roots
+   (`io.mosip.esignet.plugin.<module>` for esignet-integration-api
+   implementations, `io.mosip.signup.plugin.<module>` for
+   signup-integration-api implementations — see `mock-plugin` and
+   `mosip-identity-plugin` for examples of both).
+
+## Pull Request Guidelines
+
+- Target the `develop` branch.
+- Reference the tracking issue (e.g. `MOSIP-xxxxx` or a GitHub issue URL) in
+  the PR title/description, following the existing commit history convention
+  in this repo (see `git log`).
+- Sign off commits (`git commit -s`) — MOSIP requires a DCO sign-off line
+  matching the committer's real identity.
+- Expect CI to run the module-specific Maven build and CodeQL scan
+  automatically; a failing build or new CodeQL alert should be fixed before
+  requesting review.
+- Do not add a root `pom.xml` or otherwise couple the three modules together
+  unless that is explicitly the goal of the change — they are deliberately
+  independent, versioned and released separately.
+
+## Repository-Specific Considerations
+
+- `mock-plugin` is explicitly documented as **not for production use** — it
+  exists to exercise eSignet against the Mock IDA system. Do not point
+  production-facing changes at it; use `mosip-identity-plugin` instead.
+- Each module declares its own `<version>` in its `pom.xml` and is released
+  independently to Sonatype/Maven Central — bumping one module's version does
+  not affect the others.
+- `esignet-integration-api` and `signup-integration-api` are consumed as
+  `provided`-scope dependencies (i.e. supplied by the host esignet/esignet-
+  signup service at runtime, not bundled into the plugin jar). Keep new
+  dependencies out of `compile` scope unless they genuinely need to ship
+  inside the plugin jar.
+- The publish/Sonar/Nexus jobs in `push-trigger.yml` only run for non-PR,
+  non-release pushes off `master` — a plain PR only triggers the build (and
+  CodeQL) jobs, not publishing.
+
+## Agent rules
+
+### Do
+
+1. Work inside a single module directory (`mock-plugin`, `mosip-identity-plugin`, or `sunbird-rc-plugin`) per change, and run that module's own `mvn clean install` / `mvn test` before proposing a change as complete.
+2. Read the target module's own `README.md` before changing its configuration or documenting new properties — it is the source of truth for that module's setup.
+3. Keep new provider/service implementation classes in the correct existing package (`io.mosip.esignet.plugin.<module>` or `io.mosip.signup.plugin.<module>`) matching the interface being implemented.
+4. Target the `develop` branch for new branches and PRs.
+5. Place any `-D` system property before the Maven goal on the command line (e.g. `mvn -Dproperty=value clean install`), never after.
+
+### Do not
+
+1. Do not assume a root `pom.xml` exists — there isn't one, so do not attempt a repo-root Maven build or add cross-module dependencies between the three plugins.
+2. Do not commit real secrets, license keys, or credentials (e.g. `mosip.esignet.misp.key`, `mosip.ida.client.secret`, OSSRH/GPG/Sonar tokens) into any `application.properties` or workflow file.
+3. Do not treat `mock-plugin` as production-ready — it is documented as development/demo-only.
+4. Do not change `esignet-integration-api` / `signup-integration-api` dependency scope away from `provided` without a specific reason — they are supplied by the host service at runtime.
+5. Do not skip running the affected module's tests locally before opening a PR just because CI will also run them.

--- a/mock-plugin/AGENTS.md
+++ b/mock-plugin/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md — mock-plugin/
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+Implements interfaces from **both** `esignet-integration-api` and
+`signup-integration-api`, backed by the [Mock IDA
+system](https://github.com/mosip/esignet-mock-services/tree/master/mock-identity-system)
+instead of a real MOSIP ID Authentication service. **Development/demo
+use only — not for production.** See `../AGENTS.md`'s
+Repository-Specific Considerations for why.
+
+## Layout
+
+Two separate package roots exist side by side in this module — one per
+consumer:
+
+```text
+mock-plugin/src/main/java/
+├── io/mosip/esignet/plugin/mock/       # esignet-integration-api implementation
+│   ├── dto/                              # Kyc*RequestDto/ResponseDto (V2/V3 variants), LanguageValue
+│   └── service/
+│       ├── MockAuthenticationService.java      # implements `Authenticator`
+│       ├── MockHelperService.java
+│       └── MockKeyBindingWrapperService.java
+└── io/mosip/signup/plugin/mock/        # signup-integration-api implementation
+    ├── dto/                              # BiometricData, LanguageValue, MockIdentityRequest/Response, MockScene, MockUserStory
+    ├── service/MockProfileRegistryPluginImpl.java   # implements `ProfileRegistryPlugin`
+    ├── verifier/MockIdentityVerifierPluginImpl.java  # extends `IdentityVerifierPlugin`
+    └── util/ErrorConstants.java
+```
+
+`src/test/java` mirrors both package roots with one test class per main
+service class (5 test files total).
+
+## Key classes
+
+- **`MockAuthenticationService implements Authenticator`** — the
+  esignet-side plugin. Public API: `doKycAuth`, `doKycExchange`,
+  `sendOtp`, `isSupportedOtpChannel`, `getAllKycSigningCertificates`,
+  plus the newer `doKycAuth`/`doVerifiedKycExchange` overloads that take
+  `boolean claimsMetadataRequired`/`VerifiedKycExchangeDto`. If you add a
+  new `Authenticator` method (from an `esignet-integration-api` version
+  bump), implement it here.
+- **`MockProfileRegistryPluginImpl implements ProfileRegistryPlugin`** —
+  the signup-side plugin: `validate`, `createProfile`, `updateProfile`,
+  `getProfileCreateUpdateStatus`, `getProfile`, `isMatch`,
+  `getUISpecification`.
+- **`MockIdentityVerifierPluginImpl extends IdentityVerifierPlugin`** —
+  drives a scripted mock identity-verification flow using
+  `MockScene`/`MockUserStory` fixtures rather than a real biometric
+  verification backend.
+
+## Build & Test Commands
+
+```bash
+cd mock-plugin
+mvn clean install
+mvn test
+mvn test -Dtest=MockAuthenticationServiceTest
+```
+
+## Configuration
+
+`src/main/resources/application.properties` ships with default values
+for every property this plugin needs — see `README.md`'s Configuration
+section. Real overrides happen at the host application
+(`esignet-service`) level via environment variables, not by editing
+this file. `README.md` also documents two `key_policy_def` DB rows
+(`MOCK_AUTHENTICATION_SERVICE`, `MOCK_BINDING_SERVICE`) that must exist
+in the target `mosip_esignet` database, and a required
+`"bindingtransaction"` entry in `mosip.esignet.cache.names`.
+
+## Agent rules
+
+### Do
+
+1. Keep esignet-side changes under `io.mosip.esignet.plugin.mock` and
+   signup-side changes under `io.mosip.signup.plugin.mock` — don't mix
+   the two package roots even though they live in one module.
+2. Add a matching test class under `src/test/java` mirroring the
+   package you changed.
+3. Update `README.md`'s DB-entries section if a change requires a new
+   `key_policy_def` row or cache-name entry.
+
+### Do not
+
+1. Do not treat this module as production-ready — it's explicitly
+   development/demo-only (see `../AGENTS.md`).
+2. Do not add real credentials/keys to `application.properties` — every
+   value here is a documented default meant to be overridden by the
+   host application.

--- a/mosip-identity-plugin/AGENTS.md
+++ b/mosip-identity-plugin/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md — mosip-identity-plugin/
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+The **production** plugin: integrates eSignet with the real [MOSIP IDA
+system](https://github.com/mosip/id-authentication) and eSignet Signup
+with the real [MOSIP ID Repository](https://github.com/mosip/id-repository).
+This is what actually ships to a live MOSIP deployment — contrast with
+`../mock-plugin/`, which is explicitly demo-only.
+
+## Layout
+
+Same two-package-root pattern as `mock-plugin`:
+
+```text
+mosip-identity-plugin/src/main/java/
+├── io/mosip/esignet/plugin/mosipid/    # esignet-integration-api implementation
+│   ├── dto/                              # Ida*Request/Response, AuditRequest/Response, KeyBinding*, etc. (17 DTOs)
+│   ├── helper/AuthTransactionHelper.java
+│   └── service/
+│       ├── HelperService.java
+│       ├── IdaAuditPluginImpl.java             # implements `AuditPlugin`
+│       ├── IdaAuthenticatorImpl.java             # implements `Authenticator`
+│       └── IdaKeyBinderImpl.java                   # implements `KeyBinder`
+└── io/mosip/signup/plugin/mosipid/     # signup-integration-api implementation
+    ├── dto/                              # Identity*Request/Response, Schema*, RequestWrapper/ResponseWrapper, etc. (13 DTOs)
+    ├── service/
+    │   ├── IdrepoProfileRegistryPluginImpl.java   # implements `ProfileRegistryPlugin`
+    │   └── MockIdentityVerifierPluginImpl.java      # extends `IdentityVerifierPlugin`
+    └── util/BiometricUtil.java, ErrorConstants.java, ProfileCacheService.java
+```
+
+**Note the name**: `io.mosip.signup.plugin.mosipid.service.MockIdentityVerifierPluginImpl`
+is a *mock* identity verifier that ships inside the otherwise-production
+`mosip-identity-plugin` module — MOSIP doesn't yet have a real
+identity-verification backend integration for signup, so this
+"production" plugin still uses a mock for that one piece. Don't assume
+everything under this module is a real MOSIP-backed integration; check
+which interface/class you're touching.
+
+## Key classes
+
+- **`IdaAuthenticatorImpl implements Authenticator`** — the esignet-side
+  KYC auth/exchange/OTP implementation against real IDA services, backed
+  by `AuthTransactionHelper` and `HelperService`.
+- **`IdaAuditPluginImpl implements AuditPlugin`** — sends audit events to
+  MOSIP's Auditmanager service.
+- **`IdaKeyBinderImpl implements KeyBinder`** — handles device/key
+  binding requests against IDA.
+- **`IdrepoProfileRegistryPluginImpl implements ProfileRegistryPlugin`**
+  — signup-side profile create/update/fetch against the real MOSIP ID
+  Repository (contrast with `mock-plugin`'s
+  `MockProfileRegistryPluginImpl`, which fakes this).
+
+## Build & Test Commands
+
+```bash
+cd mosip-identity-plugin
+mvn clean install
+```
+
+Unlike `mock-plugin` and `sunbird-rc-plugin`, this module additionally
+uses `maven-assembly-plugin` with a custom `src/assembly.xml`
+(`jar-with-runtime-deps` format — plain jar output, `includeBaseDirectory`
+false, bundles compiled classes/resources plus the Maven descriptor
+metadata) — check `src/assembly.xml` before assuming standard `jar`
+packaging behavior for this module specifically.
+
+To build against a specific SNAPSHOT of `esignet-integration-api`/
+`signup-integration-api`, see `../AGENTS.md`'s Build & Test Commands
+(`mvn clean install -Designet.version=...`).
+
+## Configuration
+
+`src/main/resources/application.properties` ships with defaults for
+every configurable property — real overrides happen at the host
+application (`esignet-service`/`signup-service`) level via environment
+variables. Two properties have **no default and must be supplied by the
+deployer**:
+
+- `mosip.ida.client.secret` — generated as part of MOSIP IDA services
+  deployment.
+- `mosip.esignet.misp.key` — requires onboarding `esignet-service` as a
+  MISP (MOSIP Infra Service Provider) partner in MOSIP's Partner
+  Management Portal first (see `README.md`'s Prerequisites section).
+
+Dependent MOSIP services (per `README.md`): for the esignet interface —
+IDA services, IdRepo services, Authmanager, Auditmanager, File server;
+for the signup interface — Kernel-masterdata-service, IdRepo services,
+Authmanager, Auditmanager, Idgenerator, Credential-request-generator.
+
+## Agent rules
+
+### Do
+
+1. Keep esignet-side changes under `io.mosip.esignet.plugin.mosipid`
+   and signup-side changes under `io.mosip.signup.plugin.mosipid`.
+2. Check `src/assembly.xml` before changing this module's packaging —
+   it's the only one of the three modules that uses
+   `maven-assembly-plugin`.
+3. Treat `mosip.ida.client.secret`/`mosip.esignet.misp.key` as
+   deployer-supplied — never give them a real default value in
+   `application.properties`.
+
+### Do not
+
+1. Do not assume `MockIdentityVerifierPluginImpl` in this module is a
+   real MOSIP-backed verifier — it's a mock, despite living in the
+   production plugin module.
+2. Do not add real credentials/keys to `application.properties`.
+3. Do not change `esignet-integration-api`/`signup-integration-api`
+   dependency scope away from `provided` (see `../AGENTS.md`).

--- a/sunbird-rc-plugin/AGENTS.md
+++ b/sunbird-rc-plugin/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md — sunbird-rc-plugin/
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+Implements **only** `esignet-integration-api` (unlike `mock-plugin` and
+`mosip-identity-plugin`, which implement both esignet- and
+signup-integration-api) — wraps the
+[Sunbird-RC](https://github.com/Sunbird-RC/sunbird-rc-core) registry
+system as an eSignet authenticator/VCI plugin, compatible with
+Sunbird-RC 1.0.0. The smallest of the three modules by a wide margin.
+
+## Layout
+
+```text
+sunbird-rc-plugin/src/
+├── main/java/io/mosip/esignet/plugin/sunbirdrc/
+│   ├── dto/RegistrySearchRequestDto.java
+│   └── service/SunbirdRCAuthenticationService.java   # implements `Authenticator`
+└── test/java/io/mosip/esignet/plugin/sunbirdrc/service/
+    └── SunbirdRCAuthenticaionServiceTest.java          # note the misspelling ("Authenticaion") in the actual filename
+```
+
+Only 2 main-source files and 1 test file — this is a single-class
+plugin, not a multi-service module like the other two.
+
+## Key class
+
+**`SunbirdRCAuthenticationService implements Authenticator`** — public
+API: `initialize()`, `doKycAuth`, `doKycExchange`,
+`buildKycDataBasedOnPolicy`, `sendOtp`, `isSupportedOtpChannel`,
+`getAllKycSigningCertificates`, plus a static `b64Encode(String)`
+helper. `doKycAuth` performs a registry search against Sunbird-RC using
+`RegistrySearchRequestDto`.
+
+## Build & Test Commands
+
+```bash
+cd sunbird-rc-plugin
+mvn clean install
+mvn test
+```
+
+## Configuration
+
+Unlike the other two modules, this one's README documents configuration
+as properties the **host application** (`esignet-service`'s
+`esignet-default.properties`) must set, not just a local
+`application.properties` with defaults:
+
+```properties
+mosip.esignet.integration.scan-base-package=io.mosip.esignet.plugin.sunbirdrc
+mosip.esignet.integration.authenticator=SunbirdRCAuthenticationService
+mosip.esignet.integration.vci-plugin=SunbirdRCVCIssuancePlugin
+```
+
+Plus demo KBI (knowledge-based identity) auth-factor configuration for
+the Sunbird registry (`individual-id-field`, `field-details`) — see
+`README.md` for the full property set. Never commit real registry
+endpoints or credentials into these examples.
+
+## Agent rules
+
+### Do
+
+1. Keep this module's single-responsibility scope — it only implements
+   `Authenticator`-family interfaces for Sunbird-RC, not the full
+   `esignet-integration-api`/`signup-integration-api` surface the other
+   two modules cover.
+2. Check `README.md` for the exact `esignet-default.properties` keys
+   required in the host application when documenting configuration.
+
+### Do not
+
+1. Do not assume this module implements `signup-integration-api` — it
+   doesn't; only `esignet-integration-api`.
+2. Do not "fix" the misspelled test filename
+   (`SunbirdRCAuthenticaionServiceTest.java`) as a drive-by change —
+   rename it deliberately if asked to, not incidentally.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md giving AI coding assistants and contributors a repository overview, tech stack, build/test commands, configuration notes, and PR guidelines for the mock-plugin, mosip-identity-plugin, and sunbird-rc-plugin modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering project structure, technology stack, build and test commands, configuration, development workflow, pull-request conventions, dependency guidelines, and CI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->